### PR TITLE
Add new projects and configure service defaults

### DIFF
--- a/AspireAppHost/AspireAppHost.csproj
+++ b/AspireAppHost/AspireAppHost.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>f4828bd7-d620-4d17-a095-5eb3bd8ea205</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebApiMediatorCQRS\WebApiMediatorCQRS.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AspireAppHost/Program.cs
+++ b/AspireAppHost/Program.cs
@@ -1,0 +1,5 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddProject<Projects.WebApiMediatorCQRS>("webapimediatorcqrs");
+
+builder.Build().Run();

--- a/AspireAppHost/Properties/launchSettings.json
+++ b/AspireAppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17212;http://localhost:15164",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21219",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22178"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15164",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19183",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20166"
+      }
+    }
+  }
+}

--- a/AspireAppHost/appsettings.Development.json
+++ b/AspireAppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/AspireAppHost/appsettings.json
+++ b/AspireAppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/AspireServiceDefaults/AspireServiceDefaults.csproj
+++ b/AspireServiceDefaults/AspireServiceDefaults.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/AspireServiceDefaults/Extensions.cs
+++ b/AspireServiceDefaults/Extensions.cs
@@ -1,0 +1,119 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Microsoft.Extensions.Hosting
+{
+    // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+    // This project should be referenced by each service project in your solution.
+    // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
+    public static class Extensions
+    {
+        public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+        {
+            builder.ConfigureOpenTelemetry();
+
+            builder.AddDefaultHealthChecks();
+
+            builder.Services.AddServiceDiscovery();
+
+            builder.Services.ConfigureHttpClientDefaults(http =>
+            {
+                // Turn on resilience by default
+                http.AddStandardResilienceHandler();
+
+                // Turn on service discovery by default
+                http.AddServiceDiscovery();
+            });
+
+            // Uncomment the following to restrict the allowed schemes for service discovery.
+            // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+            // {
+            //     options.AllowedSchemes = ["https"];
+            // });
+
+            return builder;
+        }
+
+        public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+        {
+            builder.Logging.AddOpenTelemetry(logging =>
+            {
+                logging.IncludeFormattedMessage = true;
+                logging.IncludeScopes = true;
+            });
+
+            builder.Services.AddOpenTelemetry()
+                .WithMetrics(metrics =>
+                {
+                    metrics.AddAspNetCoreInstrumentation()
+                        .AddHttpClientInstrumentation()
+                        .AddRuntimeInstrumentation();
+                })
+                .WithTracing(tracing =>
+                {
+                    tracing.AddAspNetCoreInstrumentation()
+                        // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
+                        //.AddGrpcClientInstrumentation()
+                        .AddHttpClientInstrumentation();
+                });
+
+            builder.AddOpenTelemetryExporters();
+
+            return builder;
+        }
+
+        private static IHostApplicationBuilder AddOpenTelemetryExporters(this IHostApplicationBuilder builder)
+        {
+            var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+
+            if (useOtlpExporter)
+            {
+                builder.Services.AddOpenTelemetry().UseOtlpExporter();
+            }
+
+            // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
+            //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+            //{
+            //    builder.Services.AddOpenTelemetry()
+            //       .UseAzureMonitor();
+            //}
+
+            return builder;
+        }
+
+        public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+        {
+            builder.Services.AddHealthChecks()
+                // Add a default liveness check to ensure app is responsive
+                .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+
+            return builder;
+        }
+
+        public static WebApplication MapDefaultEndpoints(this WebApplication app)
+        {
+            // Adding health checks endpoints to applications in non-development environments has security implications.
+            // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
+            if (app.Environment.IsDevelopment())
+            {
+                // All health checks must pass for app to be considered ready to accept traffic after starting
+                app.MapHealthChecks("/health");
+
+                // Only health checks tagged with the "live" tag must pass for app to be considered alive
+                app.MapHealthChecks("/alive", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains("live")
+                });
+            }
+
+            return app;
+        }
+    }
+}

--- a/WebApiMediatorCQRS.sln
+++ b/WebApiMediatorCQRS.sln
@@ -3,12 +3,16 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.11.35303.130
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiMediatorCQRS", "WebApiMediatorCQRS\WebApiMediatorCQRS.csproj", "{CF13EFA0-68A7-4721-B346-4B0BB1B0EA3E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiMediatorCQRS", "WebApiMediatorCQRS\WebApiMediatorCQRS.csproj", "{CF13EFA0-68A7-4721-B346-4B0BB1B0EA3E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F2C52F13-BB51-4A1E-8C1D-94A36856507C}"
 	ProjectSection(SolutionItems) = preProject
 		notes.txt = notes.txt
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireAppHost", "AspireAppHost\AspireAppHost.csproj", "{075CFF75-1BC1-43FB-B660-3F7E77B42CC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireServiceDefaults", "AspireServiceDefaults\AspireServiceDefaults.csproj", "{B3239B77-F975-4F04-8639-3305414BEF01}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,6 +24,14 @@ Global
 		{CF13EFA0-68A7-4721-B346-4B0BB1B0EA3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF13EFA0-68A7-4721-B346-4B0BB1B0EA3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF13EFA0-68A7-4721-B346-4B0BB1B0EA3E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{075CFF75-1BC1-43FB-B660-3F7E77B42CC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{075CFF75-1BC1-43FB-B660-3F7E77B42CC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{075CFF75-1BC1-43FB-B660-3F7E77B42CC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{075CFF75-1BC1-43FB-B660-3F7E77B42CC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3239B77-F975-4F04-8639-3305414BEF01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3239B77-F975-4F04-8639-3305414BEF01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3239B77-F975-4F04-8639-3305414BEF01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3239B77-F975-4F04-8639-3305414BEF01}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebApiMediatorCQRS/Program.cs
+++ b/WebApiMediatorCQRS/Program.cs
@@ -4,6 +4,8 @@ using WebApiMediatorCQRS.Behaviors;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddServiceDefaults();
+
 var domainAssembly = typeof(Program).Assembly;
 
 // Add services to the container.
@@ -28,6 +30,8 @@ builder.Services.AddAutoMapper(domainAssembly);
 builder.ConfigureServices();
 
 var app = builder.Build();
+
+app.MapDefaultEndpoints();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/WebApiMediatorCQRS/WebApiMediatorCQRS.csproj
+++ b/WebApiMediatorCQRS/WebApiMediatorCQRS.csproj
@@ -15,4 +15,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\AspireServiceDefaults\AspireServiceDefaults.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Updated solution to include AspireAppHost and AspireServiceDefaults projects. Added AddServiceDefaults and MapDefaultEndpoints in Program.cs. Updated WebApiMediatorCQRS.csproj with a project reference. Added appsettings files for logging configuration. Created AspireAppHost.csproj and AspireServiceDefaults.csproj targeting .NET 8.0. Added launchSettings.json for launch profiles. Added Extensions.cs for common service configurations.